### PR TITLE
LIBFCREPO-892. Updated Dockerfile with specific base image versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,10 @@
+# Dockerfile for the generating the webapp image
+#
+# To build:
+#
+# docker build -t docker.lib.umd.edu/fcrepo-webapp:<VERSION> -f Dockerfile .
+#
+# where <VERSION> is the Docker image version to create.
 FROM maven:3.6.3-jdk-8-slim AS compile
 
 ENV SOURCE_DIR /opt/umd-fcrepo-webapp

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM maven AS compile
+FROM maven:3.6.3-jdk-8-slim AS compile
 
 ENV SOURCE_DIR /opt/umd-fcrepo-webapp
 COPY src $SOURCE_DIR/src
@@ -6,7 +6,7 @@ COPY pom.xml $SOURCE_DIR
 WORKDIR $SOURCE_DIR
 RUN mvn package -DwarFileName=umd-fcrepo-webapp
 
-FROM tomcat:7
+FROM tomcat:7.0.106-jdk8-openjdk-buster
 
 COPY --from=compile /opt/umd-fcrepo-webapp/target/umd-fcrepo-webapp.war /usr/local/tomcat/webapps/ROOT.war
 COPY setenv.sh /usr/local/tomcat/bin/


### PR DESCRIPTION
Updated the Dockerfile so that the base images had specific version
tags. This is intended to make it easier to reproduce a particular
Docker image by making it clear exactly which base images were used
to construct it.

https://issues.umd.edu/browse/LIBFCREPO-892